### PR TITLE
fix rest on 3.14.0

### DIFF
--- a/transcendence/requirements.txt
+++ b/transcendence/requirements.txt
@@ -1,5 +1,5 @@
 Django>=3.0,<4.0
-djangorestframework
+djangorestframework==3.14.0
 djangorestframework-simplejwt
 drf-yasg
 channels 


### PR DESCRIPTION
Une nouvelle version de Django REST framework provoque un crash de notre serveur. Au lieu de mettre à jour vers cette version, nous avons décidé de rester sur la version actuelle en la fixant dans nos requirements.txt.