### PR TITLE
typo corrected + next round btn wider

### DIFF
--- a/transcendence/base/static/js/translation/dictionnary.js
+++ b/transcendence/base/static/js/translation/dictionnary.js
@@ -121,7 +121,7 @@ export const translations = {
 	"1vs1.next": {
 		"en": "NEXT",
 		"fr": "SUIVANT",
-		"es": "JUGADOR 2"
+		"es": "SIGUIENTE"
 	},
 
 	// Placeholder

--- a/transcendence/base/static/styles/custom.css
+++ b/transcendence/base/static/styles/custom.css
@@ -169,6 +169,10 @@
 	transition: background-color 0.2s;
 }
 
+#btNextRound {
+	width: 50%;
+}
+
 .button5:hover, .button6:hover {
 	background-color: #5B5B5B;
 }


### PR DESCRIPTION
Cette PR règle une erreur de traduction et modifie le bouton "next round" qui n'était plus assez grand à cause des traductions