### PR TITLE
Fix/nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,9 @@ services:
       - ./nginx/certs:/etc/nginx/certs
       - ./nginx/conf.d:/etc/nginx/conf.d
       - static_volume:/backend/base/static
+      - ./nginx/conf/default.conf:/etc/nginx/http.d/default.conf
+      - ./nginx/logs:/var/log/nginx
+
 
   redis:
     image: redis:7

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -1,11 +1,26 @@
 server {
+    # SSL configuration
     listen 80;
-    listen [::]:80;
+    server_name localhost;
 
-    server_name 127.0.0.1;
+    location / {
+        # Proxy all requests to backend server
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
-    return 301 https://$host$request_uri;
+        # Handle WebSocket connections
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    # # Quand on essai de rediriger le http vers https, on entre dans une boucle infinie. dunno why
+    # return 301 https://$host$request_uri;  # Redirect HTTP to HTTPS
 }
+
 
 server {
     # SSL configuration
@@ -18,31 +33,18 @@ server {
 
     ssl_protocols TLSv1.2 TLSv1.3;
 
-    # Static content
-    location /static/ {
-        alias /backend/base/static/;
-    }
-
     # Proxy pass configuration for the main application
     location / {
-        try_files $uri $uri/ =404;
+        # try_files $uri $uri/ =404;
         proxy_pass http://backend:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-    }
 
-    location /ws/ {
-        proxy_pass http://backend:8000;  # Change to the actual port where Daphne is running
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
     }
-
 
 }

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -29,64 +29,64 @@ http {
 	include /etc/nginx/mime.types;
 	default_type application/octet-stream;
 
-	# Name servers used to resolve names of upstream servers into addresses.
-	# It's also needed when using tcpsocket and udpsocket in Lua modules.
-	#resolver 1.1.1.1 1.0.0.1 2606:4700:4700::1111 2606:4700:4700::1001;
+	# # Name servers used to resolve names of upstream servers into addresses.
+	# # It's also needed when using tcpsocket and udpsocket in Lua modules.
+	# #resolver 1.1.1.1 1.0.0.1 2606:4700:4700::1111 2606:4700:4700::1001;
 
-	# Don't tell nginx version to the clients. Default is 'on'.
-	server_tokens off;
+	# # Don't tell nginx version to the clients. Default is 'on'.
+	# server_tokens off;
 
-	# Specifies the maximum accepted body size of a client request, as
-	# indicated by the request header Content-Length. If the stated content
-	# length is greater than this size, then the client receives the HTTP
-	# error code 413. Set to 0 to disable. Default is '1m'.
-	client_max_body_size 1m;
+	# # Specifies the maximum accepted body size of a client request, as
+	# # indicated by the request header Content-Length. If the stated content
+	# # length is greater than this size, then the client receives the HTTP
+	# # error code 413. Set to 0 to disable. Default is '1m'.
+	# client_max_body_size 1m;
 
-	# Sendfile copies data between one FD and other from within the kernel,
-	# which is more efficient than read() + write(). Default is off.
-	sendfile on;
+	# # Sendfile copies data between one FD and other from within the kernel,
+	# # which is more efficient than read() + write(). Default is off.
+	# sendfile on;
 
-	# Causes nginx to attempt to send its HTTP response head in one packet,
-	# instead of using partial frames. Default is 'off'.
-	tcp_nopush on;
-
-
-	# Enables the specified protocols. Default is TLSv1 TLSv1.1 TLSv1.2.
-	# TIP: If you're not obligated to support ancient clients, remove TLSv1.1.
-	ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
-
-	# Path of the file with Diffie-Hellman parameters for EDH ciphers.
-	# TIP: Generate with: `openssl dhparam -out /etc/ssl/nginx/dh2048.pem 2048`
-	#ssl_dhparam /etc/ssl/nginx/dh2048.pem;
-
-	# Specifies that our cipher suits should be preferred over client ciphers.
-	# Default is 'off'.
-	ssl_prefer_server_ciphers on;
-
-	# Enables a shared SSL cache with size that can hold around 8000 sessions.
-	# Default is 'none'.
-	ssl_session_cache shared:SSL:2m;
-
-	# Specifies a time during which a client may reuse the session parameters.
-	# Default is '5m'.
-	ssl_session_timeout 1h;
-
-	# Disable TLS session tickets (they are insecure). Default is 'on'.
-	ssl_session_tickets off;
+	# # Causes nginx to attempt to send its HTTP response head in one packet,
+	# # instead of using partial frames. Default is 'off'.
+	# tcp_nopush on;
 
 
-	# Enable gzipping of responses.
-	#gzip on;
+	# # Enables the specified protocols. Default is TLSv1 TLSv1.1 TLSv1.2.
+	# # TIP: If you're not obligated to support ancient clients, remove TLSv1.1.
+	# ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 
-	# Set the Vary HTTP header as defined in the RFC 2616. Default is 'off'.
-	gzip_vary on;
+	# # Path of the file with Diffie-Hellman parameters for EDH ciphers.
+	# # TIP: Generate with: `openssl dhparam -out /etc/ssl/nginx/dh2048.pem 2048`
+	# #ssl_dhparam /etc/ssl/nginx/dh2048.pem;
+
+	# # Specifies that our cipher suits should be preferred over client ciphers.
+	# # Default is 'off'.
+	# ssl_prefer_server_ciphers on;
+
+	# # Enables a shared SSL cache with size that can hold around 8000 sessions.
+	# # Default is 'none'.
+	# ssl_session_cache shared:SSL:2m;
+
+	# # Specifies a time during which a client may reuse the session parameters.
+	# # Default is '5m'.
+	# ssl_session_timeout 1h;
+
+	# # Disable TLS session tickets (they are insecure). Default is 'on'.
+	# ssl_session_tickets off;
 
 
-	# Helper variable for proxying websockets.
-	map $http_upgrade $connection_upgrade {
-		default upgrade;
-		'' close;
-	}
+	# # Enable gzipping of responses.
+	# #gzip on;
+
+	# # Set the Vary HTTP header as defined in the RFC 2616. Default is 'off'.
+	# gzip_vary on;
+
+
+	# # Helper variable for proxying websockets.
+	# map $http_upgrade $connection_upgrade {
+	# 	default upgrade;
+	# 	'' close;
+	# }
 
 
 	# Specifies the main log format.

--- a/transcendence/transcendence/settings.py
+++ b/transcendence/transcendence/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = "django-insecure-g-py#%-k^n4gu!t!ifjry&zkcdyb0sz_9dhdton2$2f+9rfux2
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["0.0.0.0", "localhost", "127.0.0.1", "c1r8p11.42quebec.com"]
+ALLOWED_HOSTS = ["0.0.0.0", "localhost", "127.0.0.1", "backend"]
 # ALLOWED_HOSTS += ["c1r8p11.42quebec.com"]
 
 


### PR DESCRIPTION
J'ai essayé de repartir de 0 avec les config du nginx. et de garder le mininum viable. Ça semble marcher pour le http/https avec les websocket aussi.

on n'a plus accès aux port 8000. À partir de cette PR, faut entrer dans le browser:
`localhost` ou `https://localhost`

Je n'ai pas réussi à rediriger automatiquement le http vers le https, ça fait une request loop infini for some reason. 